### PR TITLE
Fix "Unable to find Device" for touchscreen as a mouse device

### DIFF
--- a/src/xinput.cc
+++ b/src/xinput.cc
@@ -35,7 +35,7 @@ int XInputTouch::find_touch(std::vector<std::pair<XID,std::string>> &ret,
 
     for (loop=0; loop<num_devices; loop++) {
 
-        if (devices[loop].type != xi_touchscreen)
+        if (devices[loop].type != xi_touchscreen && devices[loop].type != xi_mouse)
             continue;
         if (name.size() > 0 && name != devices[loop].name)
             continue;


### PR DESCRIPTION
I got a eGalax USB Touchscreen identified as mouse but has `libinput Calibration Matrix` property, it works with `--device-id` mentioned in #2 but not `--device-name` which gives "Unable to find Device" error.

This PR fixed such issue, however it's nice to do a proper check for the existence of `libinput Calibration Matrix` property.