### PR TITLE
Also detect touchscreens identifying as mice

### DIFF
--- a/src/calibrator.cc
+++ b/src/calibrator.cc
@@ -55,7 +55,7 @@ void Calibrator::getMatrix(const std::string &name, Mat9 &coeff) {
     auto ret = xinputtouch->get_prop(device_id, name.c_str(), values);
 
     if (ret < 0 || values.size() != 9)
-        throw WrongCalibratorException("Libinput: \"libinput Calibration Matrix\" property missing, not a (valid) libinput device");
+        throw WrongCalibratorException("Libinput: \"" + name + "\" property missing, not a (valid) libinput device");
 
     mat9_set_identity(coeff);
     for (unsigned int i = 0 ; i < 9 ; i++)
@@ -74,7 +74,7 @@ void Calibrator::setMatrix(const std::string &name, const Mat9 &coeff) {
 
     auto ret = xinputtouch->set_prop(device_id, name.c_str(), float_atom, format, values);
     if (ret < 0)
-        throw WrongCalibratorException("Libinput: \"libinput Calibration Matrix\" property missing, not a (valid) libinput device");
+        throw WrongCalibratorException("Libinput: \"" + name + "\" property missing, not a (valid) libinput device");
 
 
 }

--- a/src/main.cc
+++ b/src/main.cc
@@ -58,9 +58,6 @@ void show_help() {
     );
 }
 
-#define CALMATR1 "libinput Calibration Matrix"
-#define CALMATR2 "Coordinate Transformation Matrix"
-
 bool starts_with(std::string_view s1, std::string_view s2)
 {
     if (s1.size() < s2.size())

--- a/src/xinput.cc
+++ b/src/xinput.cc
@@ -63,7 +63,7 @@ int XInputTouch::find_touch(std::pair<XID,std::string> &ret)
          * xi_touchscreen
          */
         if (devices[loop].type != xi_touchscreen &&
-            has_prop(devices[loop].id, "libinput Calibration Matrix") != 0)
+            has_prop(devices[loop].id, CALMATR1) != 0)
                 continue;
 
         if (found == 0) {
@@ -442,11 +442,11 @@ int main() {
     fprintf(stderr, "r4=%d\n",r4);
     assert(r4 < 0);
 
-    xi.set_prop(devid, "libinput Calibration Matrix", {
+    xi.set_prop(devid, CALMATR1, {
         "1.0", "1.0", "1.0", "1.0", "0.5", "1.0", "0", "0", "1"
     });
 
-    xi.get_prop(devid, "libinput Calibration Matrix", r1);
+    xi.get_prop(devid, CALMATR1, r1);
     bool first;
     for(const auto &v : r1) {
         if (!first)

--- a/src/xinput.hpp
+++ b/src/xinput.hpp
@@ -55,6 +55,7 @@ public:
                         std::vector<std::string> &ret);
     int get_prop(int devid, const char *name,
                         std::vector<std::string> &ret);
+    int has_prop(int devid, const std::string &prop_name);
 
     std::vector<std::pair<int, std::string>> list_devices();
 

--- a/src/xinput.hpp
+++ b/src/xinput.hpp
@@ -36,6 +36,9 @@
 #include <vector>
 #include <utility>
 
+#define CALMATR1 "libinput Calibration Matrix"
+#define CALMATR2 "Coordinate Transformation Matrix"
+
 class XInputTouch {
 public:
     XInputTouch(Display *display);


### PR DESCRIPTION
Some touchscreens don't have a type of 'xi_touchscreen' but do have a calibartion matrix, so fall back on this property existing if we can't find anything that is an xi_touchscreen