### PR TITLE
Fixup multi-monitor support

### DIFF
--- a/src/calibrator.hpp
+++ b/src/calibrator.hpp
@@ -31,6 +31,7 @@
 
 #include "xinput.hpp"
 #include "mat9.hpp"
+#include "display_data.hpp"
 
 class WrongCalibratorException : public std::invalid_argument {
     public:
@@ -62,7 +63,7 @@ public:
     ~Calibrator();
 
     /// calculate and apply the calibration
-    bool finish(int width, int height);
+    bool finish(const DisplayData & dd, const Mat9 & prescale);
 
 
     bool set_calibration(const Mat9 &coeff);

--- a/src/display_data.hpp
+++ b/src/display_data.hpp
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2024 Simon Hyde
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#pragma once
+#include <cassert>
+
+struct DisplayData {
+    int monitor_x = 0;
+    int monitor_y = 0;
+    int monitor_width = 0;
+    int monitor_height = 0;
+    int overall_width = 0;
+    int overall_height = 0;
+    bool monitor_is_overall() {
+        return monitor_x == 0 && monitor_y == 0 && monitor_width == overall_width
+              && monitor_height == overall_height;
+    }
+};

--- a/src/gui_x11.cc
+++ b/src/gui_x11.cc
@@ -76,8 +76,8 @@ static const std::string help_text[help_lines] = {
 
 static const char* colors[nr_colors] = {"BLACK", "WHITE", "GRAY", "DIMGRAY", "RED"};
 
-GuiCalibratorX11::GuiCalibratorX11(Display *display_, int mnr)
-  : time_elapsed(0), points_count(0), monitor_nr(mnr), display(display_)
+GuiCalibratorX11::GuiCalibratorX11(Display *display_, int mnr, bool verbose_)
+  : time_elapsed(0), points_count(0), monitor_nr(mnr), display(display_), verbose(verbose_)
 {
     screen_num = DefaultScreen(display);
     // Load font and get font information structure
@@ -90,11 +90,14 @@ GuiCalibratorX11::GuiCalibratorX11(Display *display_, int mnr)
         }
     }
 
-    int x, y, w, h;
-    get_monitor_size(x, y, w, h, monitor_nr);
-    set_window_size(x, y, w, h);
+    get_monitor_size(dd.monitor_x, dd.monitor_y, dd.monitor_width, dd.monitor_height, monitor_nr);
+    set_window_size(dd.monitor_x, dd.monitor_y, dd.monitor_width, dd.monitor_height);
+    detect_display_size(dd.overall_width, dd.overall_height);
 
-    //printf("window: %d,%x x %d,%d\n", window_x, window_y, window_width, window_height);
+    if (verbose) {
+        printf("whole display: %d,%d\n",dd.overall_width, dd.overall_height);
+        printf("monitor/window: %d,%d x %d,%d\n", dd.monitor_x, dd.monitor_y, dd.monitor_width, dd.monitor_height);
+    }
     // Register events on the window
     XSetWindowAttributes attributes;
     attributes.override_redirect = True;
@@ -126,6 +129,12 @@ GuiCalibratorX11::GuiCalibratorX11(Display *display_, int mnr)
     gc = XCreateGC(display, win, 0, NULL);
     XSetFont(display, gc, font_info->fid);
 
+}
+
+void  GuiCalibratorX11::detect_display_size( int &width, int &height) {
+
+    width = DisplayWidth(display, screen_num);
+    height = DisplayHeight(display, screen_num);
 }
 
 void GuiCalibratorX11::get_monitor_size(int &x, int &y, int &w, int &h,

--- a/src/gui_x11.hpp
+++ b/src/gui_x11.hpp
@@ -28,6 +28,8 @@
 #include <functional>
 #include <utility>
 
+#include "display_data.hpp"
+
 enum { BLACK=0, WHITE=1, GRAY=2, DIMGRAY=3, RED=4 };
 inline const int nr_colors = 5;
 /*
@@ -65,12 +67,13 @@ class GuiCalibratorX11
 public:
     ~GuiCalibratorX11();
     bool mainloop();
-    GuiCalibratorX11(Display *display, int monitor_nr = 1);
+    GuiCalibratorX11(Display *display, int monitor_nr = 1, bool verbose = false);
 
 private:
     // Data
     double X[4], Y[4];
     int window_x, window_y, window_width, window_height;
+    DisplayData dd;
     int time_elapsed;
     int points_count;
     bool return_value;
@@ -80,6 +83,7 @@ private:
 
     // X11 vars
     Display* display;
+    bool verbose;
     int screen_num;
     Window win;
     GC gc;
@@ -103,6 +107,7 @@ private:
     std::function<void(void)> reset_ext = [](){ };
 
     void get_monitor_size(int &x, int &y, int &w, int &h, int monitor_num = 0);
+    void detect_display_size(int &w, int &h);
 
 public:
     void set_add_click(std::function<bool(int, int)> f) {
@@ -112,6 +117,7 @@ public:
         reset_ext = f;
     }
 
-    std::pair<int, int> get_display_size() { return {window_width,
-                                                        window_height}; }
+    DisplayData get_display_data() {
+	    return dd;
+    }
 };


### PR DESCRIPTION
Multiple monitors with different resolutions wouldn't work, because clicks were generated with odd values in corners where no monitor existed. This fixes the calibration so it works correctly on a single monitor on multi-monitor setups