### PR TITLE
Fixup multi-monitor transform

### DIFF
--- a/src/calibrator.cc
+++ b/src/calibrator.cc
@@ -307,7 +307,7 @@ bool Calibrator::finish(int width, int height)
      */
     Mat9 actual_matrix;
     getMatrix(matrix_name, actual_matrix);
-    mat9_product(coeff, actual_matrix, result_coeff);
+    mat9_product(actual_matrix, coeff, result_coeff);
 
     return true;
 }


### PR DESCRIPTION
This was producing incorrect translations if there was a rotation or flip in the calibration. Reversing the matrix product produces the correct calibration matrix.